### PR TITLE
Add missing actioncable assets to gemspec.

### DIFF
--- a/actioncable/actioncable.gemspec
+++ b/actioncable/actioncable.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.email    = ["pratiknaik@gmail.com", "david@loudthinking.com"]
   s.homepage = "https://rubyonrails.org"
 
-  s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*", "app/assets/javascripts/action_cable.js"]
+  s.files        = Dir["CHANGELOG.md", "MIT-LICENSE", "README.md", "lib/**/*", "app/assets/javascripts/*.js"]
   s.require_path = "lib"
 
   s.metadata = {


### PR DESCRIPTION
### Summary
actioncable.js and actioncable.esm.js is not included to gem package. It prevented us from using the action cable when using importmaps.

When we use actioncable with importmaps, it needs to write as below in `importmaps.rb`. 

```
pin "@rails/actioncable", to: "actioncable.esm.js"
```

But `actioncable.esm.js` would not be loaded, because esm version of actioncable's javascript is not included in actioncable gem.

This patch adds the missing asset files to gem package.

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
